### PR TITLE
(fix) monitors.get() error

### DIFF
--- a/monitors.test.ts
+++ b/monitors.test.ts
@@ -85,15 +85,17 @@ describe("MonitorsApiClient", () => {
   describe("#get", () => {
     it("gets a Monitor via GET /api/v0/monitors/:monitorId", async () => {
       const handler = spy((_?: FetchOptions) => ({
-        id: "monitor-0",
-        name: "my monitor",
-        memo: "test",
-        notificationInterval: 60,
-        isMute: false,
-        type: "connectivity",
-        scopes: ["foo"],
-        excludeScopes: ["bar"],
-        alertStatusOnGone: "CRITICAL",
+        monitor: {
+          id: "monitor-0",
+          name: "my monitor",
+          memo: "test",
+          notificationInterval: 60,
+          isMute: false,
+          type: "connectivity",
+          scopes: ["foo"],
+          excludeScopes: ["bar"],
+          alertStatusOnGone: "CRITICAL",
+        }
       }));
       const fetcher = new MockFetcher()
         .mock("GET", "/api/v0/monitors/monitor-0", handler);

--- a/monitors.test.ts
+++ b/monitors.test.ts
@@ -95,7 +95,7 @@ describe("MonitorsApiClient", () => {
           scopes: ["foo"],
           excludeScopes: ["bar"],
           alertStatusOnGone: "CRITICAL",
-        }
+        },
       }));
       const fetcher = new MockFetcher()
         .mock("GET", "/api/v0/monitors/monitor-0", handler);

--- a/monitors.ts
+++ b/monitors.ts
@@ -307,12 +307,12 @@ export class MonitorsApiClient {
   }
 
   async get(monitorId: string, options?: ApiOptions): Promise<Monitor> {
-    const res = await this.fetcher.fetch<RawMonitor>(
+    const res = await this.fetcher.fetch<{ monitor: RawMonitor }>(
       "GET",
       `/api/v0/monitors/${monitorId}`,
       { signal: options?.signal },
     );
-    return fromRawMonitor(res);
+    return fromRawMonitor(res.monitor);
   }
 
   async create(input: CreateMonitorInput, options?: ApiOptions): Promise<Monitor> {


### PR DESCRIPTION
Currently, the following error occurs when using the `monitors.get()` method.

```
error: Uncaught (in promise) Error: Unknown monitor type: undefined
throw new Error(`Unknown monitor type: ${type}`, { cause: raw });
```

https://github.com/susisu/mackerel-client/blob/8b427bd68e55e0ee96f82e04ebbbd6c00f7a6cc3/monitors.ts#L602-L606

This is because the response of the `/api/v0/monitors/<monitorId>` API is `{monitor: Monitor}`, not `Monitor`. (ref: https://mackerel.io/api-docs/entry/monitors#get)

Note that the response of the `/api/v0/monitors` API is `Monitor[]`.